### PR TITLE
replace `sed` with pure Zsh parameter expansion (#1)

### DIFF
--- a/functions/show-path
+++ b/functions/show-path
@@ -2,6 +2,7 @@
 
 # function to show the $PATH line by line
 show-path () {
-  sed 's/:/\n/g' <<< "$PATH"
+  # convert Zsh's space-delimited `$path` into a newline-delimited `(F)` array
+  # https://zsh.sourceforge.io/Doc/Release/Expansion.html#Parameter-Expansion-Flags
+  <<<${(F)path}
 }
-


### PR DESCRIPTION
- [x] remove `sed` requirement (#1)
- [x] replace the colon-delimited `$PATH` with Zsh’s space-delimited `$path`
- [x] replace `$path` array spaces with newlines using Zsh’s `F` parameter-expansion flag